### PR TITLE
add EMP IRSSI-autodl file

### DIFF
--- a/static/empornium.xml
+++ b/static/empornium.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<!-- ***** BEGIN LICENSE BLOCK *****
+   - Version: MPL 1.1
+   -
+   - The contents of this file are subject to the Mozilla Public License Version
+   - 1.1 (the "License"); you may not use this file except in compliance with
+   - the License. You may obtain a copy of the License at
+   - http://www.mozilla.org/MPL/
+   -
+   - Software distributed under the License is distributed on an "AS IS" basis,
+   - WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+   - for the specific language governing rights and limitations under the
+   - License.
+   -
+   - The Original Code is IRC Auto Downloader.
+   -
+   - The Initial Developer of the Original Code is
+   - David Nilsson.
+   - Portions created by the Initial Developer are Copyright (C) 2010, 2011
+   - the Initial Developer. All Rights Reserved.
+   -
+   - Contributor(s):
+   -
+   - ***** END LICENSE BLOCK ***** -->
+   
+<trackerinfo
+  type="empornium"
+	shortName="empornium"
+	longName="Empornium"
+	siteName="empornium.me">
+	
+	<settings>
+		<gazelle_description/>
+		<gazelle_authkey/>
+		<gazelle_torrent_pass/>
+	</settings>
+	
+	<servers>
+		<server
+			network="DigitalIRC"
+			serverNames="irc.empornium.me"
+			channelNames="#empornium-announce"
+			announcerNames="^Wizard^"
+			/>
+	</servers>
+	
+	<parseinfo>
+		<linepatterns>
+			<extract>
+				<regex value="^\[(.*?)\] (.*?) -- Uploader: (.*?) -- http?\:\/\/([^\/]+\/).*[&amp;\?]id=(.*)$"/>
+				<vars>
+					<var name="category"/>
+					<var name="torrentName"/>
+					<var name="uploader"/>
+					<var name="$baseUrl"/>
+					<var name="$torrentId"/>
+				</vars>
+			</extract>
+		</linepatterns>
+		<linematched>
+			<var name="torrentUrl">
+				<string value="http://"/>
+				<var name="$baseUrl"/>
+				<string value="torrents.php?action=download&amp;id="/>
+				<var name="$torrentId"/>
+				<string value="&amp;authkey="/>
+				<var name="authkey"/>
+				<string value="&amp;torrent_pass="/>
+				<var name="torrent_pass"/>
+			</var>
+		</linematched>
+		<ignore>
+		</ignore>
+	</parseinfo>
+</trackerinfo>


### PR DESCRIPTION
We should probably have this in the git since it means you don't have to rely on external hosting (not like it's been removed at least 3 times).
